### PR TITLE
Support converting Color struct into color types from the palette crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
 members = [
-    "lib",
+	"lib",
 	"html_visualizer"
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,3 +13,4 @@ keywords = ["color", "colors", "colour", "css", "converter"]
 [dependencies]
 regex = "1"
 lazy_static = "1"
+palette = { version = "~0.4.1", optional = true }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -62,6 +62,18 @@ extern crate lazy_static;
 
 extern crate regex;
 
+#[cfg(feature = "palette")]
+#[macro_use]
+extern crate palette;
+
+#[cfg(feature = "palette")]
+use palette::{
+    IntoColor, LinSrgba, Srgb,
+    rgb::{Rgb, RgbSpace},
+    encoding::Linear,
+    white_point::D65,
+};
+
 use self::regex::Regex;
 use std::f64::consts::PI;
 use std::str::FromStr;
@@ -71,7 +83,9 @@ fn round_with_precision(number: f64, precision: u8) -> f64 {
     (number * multiplier).round() / multiplier
 }
 
-#[derive(Copy, Clone)]
+#[cfg_attr(feature = "palette", derive(IntoColor))]
+#[cfg_attr(feature = "palette", palette_manual_into(Rgb = "into_palette_rgb"))]
+#[derive(Copy, Clone, PartialEq)]
 pub struct Color {
     pub red: u8,
     pub green: u8,
@@ -3646,6 +3660,16 @@ impl Color {
         }
 
         t / Color::LAB_CONSTANT_T2 + Color::LAB_CONSTANT_T0
+    }
+
+    #[cfg(feature = "palette")]
+    fn into_palette_rgb<S>(self) -> Rgb<Linear<S>, f32>
+    where
+        S: RgbSpace<WhitePoint = D65>,
+    {
+        Srgb::new(self.red, self.green, self.blue)
+                    .into_format()
+                    .into_rgb()
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -90,6 +90,7 @@ pub struct Color {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
+    #[cfg_attr(feature = "palette", palette_alpha)]
     pub alpha: u8,
 }
 


### PR DESCRIPTION
By adding a `Color::into_palette_rgb` function and some related boilerplate, we can support (conditionally with the optional dependency on [`palette`](https://docs.rs/palette/0.4.1/palette/index.html)) the [`palette::IntoColor`](https://docs.rs/palette/0.4.1/palette/trait.IntoColor.html) trait (and therefore conversion into any of the palette color-types) to take advantage of the palette crate's sophisticated color math and conversions.

To-do:
- Tests

Is this something you'd be interested in supporting / merging? If so, I can write some tests and tweak the API if need be.

